### PR TITLE
Allow optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - Injection of function and class constructors
 - Detection of contained factories names
 - Detection of dependencies from parameter names
+- Fallback to parameters default values
 - Clean error on dependencies cycle
 - Extensible dependencies caching policies
 

--- a/examples/node6.js
+++ b/examples/node6.js
@@ -1,0 +1,59 @@
+"use strict";
+
+const assert = require("assert");
+
+const piquouze = require("..");
+
+const container = new piquouze.Container();
+
+container.registerValue("a", 1);
+container.registerValue("b", 2);
+container.registerValue("c", 3);
+
+container.registerFactory("d", function (a, b) {
+  return a * 10 + b;
+});
+
+container.registerFactory(function e(c) {
+  return c * c;
+});
+
+const child = container.createChild();
+
+child.registerValue("b", 20); // Override a dependency.
+
+let target = function (a, b, c, d, e, ...args) {
+  return [a, b, c, d, e].concat(args);
+};
+
+assert.deepEqual(
+  container.inject(target)("foo", true),
+  [1, 2, 3, 12, 9, "foo", true]
+);
+
+assert.deepEqual(
+  child.inject(target)("foo", true),
+  [1, 20, 3, 30, 9, "foo", true]
+);
+
+target = function (a, x = 13, y = {z: new Array()}, ...args) {
+  return [a, x, y].concat(args);
+};
+
+assert.deepEqual(
+  container.inject(target)("foo", true),
+  [1, 13, {z: []}, "foo", true]
+);
+
+target = function(a, x, y, ...args) {
+  return [a, x, y].concat(args);
+};
+target.$defaults = {
+  x: 42,
+  y: (e) => e * 10,
+};
+
+assert.deepEqual(
+  container.inject(target)("foo", true),
+  [1, 42, 90, "foo", true]
+);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "doc": "jsdoc --destination doc --recurse src",
     "lint": "eslint . --ignore-path .gitignore",
     "unittest": "mocha --check-leaks --require ./alias --recursive test",
-    "unitcov": "istanbul cover --report lcovonly -- _mocha --reporter spec --check-leaks --require ./alias --recursive test",
+    "unitcov": "istanbul cover -x 'examples/**' --report lcovonly -- _mocha --reporter spec --check-leaks --require ./alias --recursive test",
     "test": "npm run unitcov",
     "posttest": "cat coverage/lcov.info | coveralls"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/pinicarus/piquouze#readme",
   "dependencies": {
+    "escodegen": "^1.8.0",
     "esprima": "^2.7.2"
   },
   "devDependencies": {

--- a/src/mark.js
+++ b/src/mark.js
@@ -14,7 +14,7 @@ const makeScanner = function (functor) {
 };
 
 /**
- * Marks a functor with the names of its injectable dependencies.
+ * Marks a functor with the names of its injectable properties.
  * @private
  *
  * @param {Function} functor - The functor to mark for injection.
@@ -39,7 +39,10 @@ const mark = function mark(functor) {
   if (!(inject instanceof Array)) {
     functor.$inject = inject = scanner().getParams();
   }
-  return inject;
+  if (!(functor.$defaults instanceof Object)) {
+    functor.$defaults = scanner().getDefaults();
+  }
+  return inject
 };
 
 module.exports = mark;

--- a/src/mark.js
+++ b/src/mark.js
@@ -19,12 +19,10 @@ const makeScanner = function (functor) {
  *
  * @param {Function} functor - The functor to mark for injection.
  *
- * @returns {String[]}  The marked names of injectable parameters.
- * @throws  {ScanError} Whenever scanning of the functor failed.
+ * @throws {ScanError} Whenever scanning of the functor failed.
  */
 const mark = function mark(functor) {
   const scanner = makeScanner(functor);
-  let   inject  = functor.$inject;
 
   if (typeof functor.$kind !== "string") {
     functor.$kind = scanner().getKind();
@@ -36,13 +34,12 @@ const mark = function mark(functor) {
       functor.$name = name;
     }
   }
-  if (!(inject instanceof Array)) {
-    functor.$inject = inject = scanner().getParams();
+  if (!(functor.$inject instanceof Array)) {
+    functor.$inject = scanner().getParams();
   }
   if (!(functor.$defaults instanceof Object)) {
     functor.$defaults = scanner().getDefaults();
   }
-  return inject
 };
 
 module.exports = mark;

--- a/test/mark.js
+++ b/test/mark.js
@@ -17,6 +17,7 @@ describe("mark", function () {
       assert.equal(functor.$kind, "function");
       assert.equal(functor.$name, undefined);
       assert.deepEqual(functor.$inject, []);
+      assert.deepEqual(functor.$defaults, {});
     });
 
     it("should mark named function", function () {
@@ -26,6 +27,7 @@ describe("mark", function () {
       assert.equal(functor.$kind, "function");
       assert.equal(functor.$name, "f");
       assert.deepEqual(functor.$inject, []);
+      assert.deepEqual(functor.$defaults, {});
     });
 
     it("should mark arrow function", function () {
@@ -35,6 +37,7 @@ describe("mark", function () {
       assert.equal(functor.$kind, "arrow");
       assert.equal(functor.$name, undefined);
       assert.deepEqual(functor.$inject, []);
+      assert.deepEqual(functor.$defaults, {});
     });
   });
 
@@ -46,6 +49,7 @@ describe("mark", function () {
       assert.equal(functor.$kind, "function");
       assert.equal(functor.$name, undefined);
       assert.deepEqual(functor.$inject, ["a"]);
+      assert.deepEqual(functor.$defaults, {});
     });
 
     it("should mark named function", function () {
@@ -55,6 +59,7 @@ describe("mark", function () {
       assert.equal(functor.$kind, "function");
       assert.equal(functor.$name, "f");
       assert.deepEqual(functor.$inject, ["a"]);
+      assert.deepEqual(functor.$defaults, {});
     });
 
     it("should mark arrow function", function () {
@@ -64,6 +69,7 @@ describe("mark", function () {
       assert.equal(functor.$kind, "arrow");
       assert.equal(functor.$name, undefined);
       assert.deepEqual(functor.$inject, ["a"]);
+      assert.deepEqual(functor.$defaults, {});
     });
   });
 
@@ -75,6 +81,7 @@ describe("mark", function () {
       assert.equal(functor.$kind, "function");
       assert.equal(functor.$name, undefined);
       assert.deepEqual(functor.$inject, ["a", "b"]);
+      assert.deepEqual(functor.$defaults, {});
     });
 
     it("should mark named function", function () {
@@ -84,6 +91,7 @@ describe("mark", function () {
       assert.equal(functor.$kind, "function");
       assert.equal(functor.$name, "f");
       assert.deepEqual(functor.$inject, ["a", "b"]);
+      assert.deepEqual(functor.$defaults, {});
     });
 
     it("should mark arrow function", function () {
@@ -93,6 +101,7 @@ describe("mark", function () {
       assert.equal(functor.$kind, "arrow");
       assert.equal(functor.$name, undefined);
       assert.deepEqual(functor.$inject, ["a", "b"]);
+      assert.deepEqual(functor.$defaults, {});
     });
   });
 
@@ -102,6 +111,7 @@ describe("mark", function () {
     functor.$kind = "custom";
     mark(functor);
     assert.equal(functor.$kind, "custom");
+    assert.deepEqual(functor.$defaults, {});
   });
 
   it("should accept given $name", function () {
@@ -110,6 +120,7 @@ describe("mark", function () {
     functor.$name= "custom";
     mark(functor);
     assert.equal(functor.$name, "custom");
+    assert.deepEqual(functor.$defaults, {});
   });
 
   it("should accept given $inject names", function () {
@@ -118,5 +129,6 @@ describe("mark", function () {
     functor.$inject = ["d", "e", "f"];
     mark(functor);
     assert.deepEqual(functor.$inject, ["d", "e", "f"]);
+    assert.deepEqual(functor.$defaults, {});
   });
 });

--- a/test/scanner.js
+++ b/test/scanner.js
@@ -19,6 +19,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "arrow");
       assert.equal(scanner.getName(), null);
       assert.deepEqual(scanner.getParams(), []);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan anonymous function", function () {
@@ -27,6 +28,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "function");
       assert.equal(scanner.getName(), null);
       assert.deepEqual(scanner.getParams(), []);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan named function", function () {
@@ -35,6 +37,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "function");
       assert.equal(scanner.getName(), "f");
       assert.deepEqual(scanner.getParams(), []);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan anonymous class", function () {
@@ -43,6 +46,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "class");
       assert.equal(scanner.getName(), null);
       assert.deepEqual(scanner.getParams(), []);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan anonymous extending class", function () {
@@ -55,6 +59,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "class");
       assert.equal(scanner.getName(), null);
       assert.deepEqual(scanner.getParams(), []);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan named class", function () {
@@ -63,6 +68,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "class");
       assert.equal(scanner.getName(), "C");
       assert.deepEqual(scanner.getParams(), []);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan named extending class", function () {
@@ -75,6 +81,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "class");
       assert.equal(scanner.getName(), "C");
       assert.deepEqual(scanner.getParams(), []);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan class not starting with constructor", function () {
@@ -86,6 +93,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "class");
       assert.equal(scanner.getName(), null);
       assert.deepEqual(scanner.getParams(), []);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
   });
 
@@ -96,6 +104,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "arrow");
       assert.equal(scanner.getName(), null);
       assert.deepEqual(scanner.getParams(), ["a"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan anonymous arrow function w/ parenthesis", function () {
@@ -104,6 +113,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "arrow");
       assert.equal(scanner.getName(), null);
       assert.deepEqual(scanner.getParams(), ["a"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan anonymous function", function () {
@@ -112,6 +122,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "function");
       assert.equal(scanner.getName(), null);
       assert.deepEqual(scanner.getParams(), ["a"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan named function", function () {
@@ -120,6 +131,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "function");
       assert.equal(scanner.getName(), "f");
       assert.deepEqual(scanner.getParams(), ["a"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan anonymous class", function () {
@@ -128,6 +140,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "class");
       assert.equal(scanner.getName(), null);
       assert.deepEqual(scanner.getParams(), ["a"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan anonymous extending class", function () {
@@ -140,6 +153,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "class");
       assert.equal(scanner.getName(), null);
       assert.deepEqual(scanner.getParams(), ["a"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan named class", function () {
@@ -148,6 +162,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "class");
       assert.equal(scanner.getName(), "C");
       assert.deepEqual(scanner.getParams(), ["a"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan named extending class", function () {
@@ -160,6 +175,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "class");
       assert.equal(scanner.getName(), "C");
       assert.deepEqual(scanner.getParams(), ["a"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan class not starting with constructor", function () {
@@ -172,6 +188,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "class");
       assert.equal(scanner.getName(), null);
       assert.deepEqual(scanner.getParams(), ["a"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should not mistake constructor", function () {
@@ -188,6 +205,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "class");
       assert.equal(scanner.getName(), null);
       assert.deepEqual(scanner.getParams(), ["a"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
   });
 
@@ -198,6 +216,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "arrow");
       assert.equal(scanner.getName(), null);
       assert.deepEqual(scanner.getParams(), ["a", "b"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan anonymous function", function () {
@@ -206,6 +225,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "function");
       assert.equal(scanner.getName(), null);
       assert.deepEqual(scanner.getParams(), ["a", "b"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan named function", function () {
@@ -214,6 +234,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "function");
       assert.equal(scanner.getName(), "f");
       assert.deepEqual(scanner.getParams(), ["a", "b"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan anonymous class", function () {
@@ -224,6 +245,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "class");
       assert.equal(scanner.getName(), null);
       assert.deepEqual(scanner.getParams(), ["a", "b"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan anonymous extending class", function () {
@@ -236,6 +258,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "class");
       assert.equal(scanner.getName(), null);
       assert.deepEqual(scanner.getParams(), ["a", "b"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan named class", function () {
@@ -244,6 +267,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "class");
       assert.equal(scanner.getName(), "C");
       assert.deepEqual(scanner.getParams(), ["a", "b"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan named extending class", function () {
@@ -256,6 +280,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "class");
       assert.equal(scanner.getName(), "C");
       assert.deepEqual(scanner.getParams(), ["a", "b"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should scan class not starting with constructor", function () {
@@ -267,6 +292,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "class");
       assert.equal(scanner.getName(), null);
       assert.deepEqual(scanner.getParams(), ["a", "b"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
 
     it("should not mistake constructor", function () {
@@ -283,6 +309,7 @@ describe("Scanner", function () {
       assert.equal(scanner.getKind(), "class");
       assert.equal(scanner.getName(), null);
       assert.deepEqual(scanner.getParams(), ["a", "b"]);
+      assert.deepEqual(scanner.getDefaults(), {});
     });
   });
 


### PR DESCRIPTION
Unresolved dependencies can now fallback to default values, either as given as function default parameters (in which case they cannot depend on external identifiers) or as decorations on the functor itself (in which case they can in turn be injected):

```javascript
functor.$default = {
  dependency1: 1, // A non-function default value
  dependency2: (otherDependency) => otherDependency.value // A injected functor returning the default value
};
```