### PR TITLE
Migrate to esprima 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 
 	"dependencies": {
 		"escodegen": "1.8.1",
-		"esprima":   "3.1.3",
+		"esprima":   "4.0.0",
 		"facies":    "3.0.2"
 	},
 


### PR DESCRIPTION
With esprima before version 3 any function which included async/await would cause a parse error.  Updating esprima to 4 fixes this, and the tests still all pass.